### PR TITLE
feat(explorer/build): only show relevant build options when module project is selected

### DIFF
--- a/package.json
+++ b/package.json
@@ -759,16 +759,16 @@
       "view/item/context": [
         {
           "command": "titanium.package.run",
-          "when": "view == titanium.view.buildExplorer && viewItem =~ /PlatformNode|DistributeNode/"
+          "when": "view == titanium.view.buildExplorer && viewItem =~ /PlatformNode|DistributeNode|ModulePackageNode/"
         },
         {
           "command": "titanium.package.run",
-          "when": "view == titanium.view.buildExplorer && viewItem =~ /PlatformNode|DistributeNode/",
+          "when": "view == titanium.view.buildExplorer && viewItem =~ /PlatformNode|DistributeNode|ModulePackageNode/",
           "group": "inline"
         },
         {
           "command": "titanium.build.run",
-          "when": "view == titanium.view.buildExplorer && viewItem == DeviceNode",
+          "when": "view == titanium.view.buildExplorer && viewItem =~ /DeviceNode|ModuleBuildNode/",
           "group": "inline"
         },
         {
@@ -778,7 +778,7 @@
         },
         {
           "command": "titanium.build.run",
-          "when": "view == titanium.view.buildExplorer && viewItem =~ /PlatformNode|TargetNode|OSVerNode|DeviceNode/"
+          "when": "view == titanium.view.buildExplorer && viewItem =~ /PlatformNode|TargetNode|OSVerNode|DeviceNode|ModuleBuildNode/"
         },
         {
           "command": "titanium.build.debug",

--- a/src/explorer/nodes/moduleBuildNode.ts
+++ b/src/explorer/nodes/moduleBuildNode.ts
@@ -1,0 +1,23 @@
+import { BaseNode } from './baseNode';
+
+import { TreeItemCollapsibleState } from 'vscode';
+import { Platform } from '../../types/common';
+import {  } from '../../types/cli';
+
+export class ModuleBuildNode extends BaseNode {
+
+	public readonly collapsibleState = TreeItemCollapsibleState.None;
+	public readonly contextValue: string = 'ModuleBuildNode';
+
+	constructor (
+		public override readonly label: string,
+		public readonly platform: Platform,
+		public readonly target: string,
+	) {
+		super(label);
+	}
+
+	get tooltip (): string {
+		return this.label;
+	}
+}

--- a/src/explorer/nodes/modulePackageNode.ts
+++ b/src/explorer/nodes/modulePackageNode.ts
@@ -1,0 +1,23 @@
+import { BaseNode } from './baseNode';
+
+import { TreeItemCollapsibleState } from 'vscode';
+import { Platform } from '../../types/common';
+import {  } from '../../types/cli';
+
+export class ModulePackageNode extends BaseNode {
+
+	public readonly collapsibleState = TreeItemCollapsibleState.None;
+	public readonly contextValue: string = 'ModulePackageNode';
+
+	constructor (
+		public override readonly label: string,
+		public readonly platform: Platform,
+		public readonly target: string,
+	) {
+		super(label);
+	}
+
+	get tooltip (): string {
+		return this.label;
+	}
+}

--- a/src/explorer/nodes/platformNode.ts
+++ b/src/explorer/nodes/platformNode.ts
@@ -1,10 +1,13 @@
 import { BaseNode } from './baseNode';
 import { TargetNode } from './targetNode';
+import { DistributeNode } from './distributeNode';
+import { ModuleBuildNode } from './moduleBuildNode';
+import { ModulePackageNode } from './modulePackageNode';
 
 import { TreeItemCollapsibleState } from 'vscode';
 import { Platform, PlatformPretty } from '../../types/common';
 import { nameForPlatform } from '../../utils';
-import { DistributeNode } from './distributeNode';
+import { ExtensionContainer } from '../../container';
 
 export class PlatformNode extends BaseNode {
 
@@ -20,7 +23,16 @@ export class PlatformNode extends BaseNode {
 		this.contextValue = 'PlatformNode';
 	}
 
-	public override getChildren (): Array<DistributeNode|TargetNode> {
+	public override getChildren (): Array<DistributeNode|TargetNode>|Array<ModuleBuildNode|ModulePackageNode> {
+		// Detect the first project to see whether we show the full explorer or a limited explorer
+		const project = Array.from(ExtensionContainer.projects.values())[0];
+		if (project.type === 'module') {
+			return [
+				new ModuleBuildNode('Build', this.platform, this.label),
+				new ModulePackageNode('Package', this.platform, this.label)
+			];
+		}
+
 		switch (this.platform) {
 			case 'android':
 				return [


### PR DESCRIPTION
When a module is project is "selected" (i.e the first Titanium project loaded in the workspace) the
build explorer will now show simplified options of only Build and Package for the build choices

Closes #993