### PR TITLE
fix(explorer/help): update VS Code documentation link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titanium-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "displayName": "Titanium",
   "description": "Intellisense, snippets, and integrated build tools for Titanium",
   "icon": "images/logo-titanium.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titanium-sdk",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "displayName": "Titanium",
   "description": "Intellisense, snippets, and integrated build tools for Titanium",
   "icon": "images/logo-titanium.png",

--- a/src/explorer/helpExplorer.ts
+++ b/src/explorer/helpExplorer.ts
@@ -25,7 +25,7 @@ export class HelpExplorer implements vscode.TreeDataProvider<BaseNode> {
 
 		return [
 			new UrlNode('Titanium SDK Documentation', 'https://titaniumsdk.com/api/', 'book'),
-			new UrlNode('Titanium Extension Documentation', 'https://titaniumsdk.com/guide/Titanium_SDK/Titanium_SDK_How-tos/Visual_Studio_Code_Extension_for_Titanium/', 'book'),
+			new UrlNode('Titanium Extension Documentation', 'https://titaniumsdk.com/guide/Editor_IDE/VSCode_Extension/', 'book'),
 			new UrlNode('TiSlack', 'https://tislack.org', 'comment-discussion'),
 			new CommandNode('Report Extension Issue', VSCodeCommands.ReportIssue, [ ExtensionId ], 'report'),
 			new CommandNode('Configure Settings', VSCodeCommands.OpenSettings, [ `@ext:${ExtensionId}` ], 'settings-gear'),


### PR DESCRIPTION
old link leads to a 404 since we've changed the docs a while ago