### PR TITLE
feat: add environment issues handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -292,6 +292,11 @@
         "category": "Titanium"
       },
       {
+        "command": "titanium.environment.fixIssues",
+        "title": "Fix environment issues",
+        "category": "Titanium"
+      },
+      {
         "command": "titanium.task.generate",
         "title": "Generate task",
         "category": "Titanium"
@@ -521,6 +526,11 @@
         "view": "titanium.view.welcome",
         "contents": "Please trust this workspace to use the Titanium extension.\n[Manage Workspace Trust](command:workbench.trust.manage)\n[Learn more about Workspace Trust](https://aka.ms/vscode-workspace-trust)",
         "when": "titanium:needsTrustedWorkspace"
+      },
+      {
+        "view": "titanium.view.welcome",
+        "contents": "There are issues with your environment. Please fix them in order for the extension to load.\n[Fix Issues](command:titanium.environment.fixIssues)",
+        "when": "titanium:environmentIssues"
       }
     ],
     "menus": {
@@ -608,6 +618,10 @@
         {
           "command": "titanium.alloy.generate.widget",
           "when": "!titanium:needsTrustedWorkspace && titanium:enabled"
+        },
+        {
+          "command": "titanium.environment.fixIssues",
+          "when": "isWorkspaceTrusted && titanium:environmentIssues"
         },
         {
           "command": "titanium.updates.openReleaseNotes",

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -16,6 +16,7 @@ export enum Commands {
 	Debug = 'titanium.build.debug',
 	DisableLiveView = 'titanium.build.setLiveViewDisabled',
 	EnableLiveView = 'titanium.build.setLiveViewEnabled',
+	FixEnvironmentIssues = 'titanium.environment.fixIssues',
 	GenerateAlloyController = 'titanium.alloy.generate.controller',
 	GenerateAlloyMigration = 'titanium.alloy.generate.migration',
 	GenerateAlloyModel = 'titanium.alloy.generate.model',

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,8 +22,8 @@ import { UpdateInfo } from 'titanium-editor-commons/updates';
 import { installUpdates } from '../updates';
 import { generateTask } from './generateTask';
 import { createKeystore } from './createKeystore';
-import { writeFile } from 'fs/promises';
 import { readJSON } from 'fs-extra';
+import { startup } from '../extension';
 
 export function registerCommand (commandId: string, callback: (...args: any[]) => unknown): void {
 	ExtensionContainer.context.subscriptions.push(
@@ -215,6 +215,10 @@ export function registerCommands (): void {
 
 	registerCommand(Commands.ShowOutputChannel, () => {
 		ExtensionContainer.outputChannel.show();
+	});
+
+	registerCommand(Commands.FixEnvironmentIssues, async () => {
+		startup();
 	});
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,8 @@ export enum GlobalState {
 	RefreshEnvironment = 'titanium:environment:refresh',
 	MissingTooling = 'titanium:toolingMissing',
 	NotTitaniumProject = 'titanium:notProject',
-	NeedsTrustedWorkspace = 'titanium:needsTrustedWorkspace'
+	NeedsTrustedWorkspace = 'titanium:needsTrustedWorkspace',
+	EnvironmentIssues = 'titanium:environmentIssues'
 }
 
 export enum WorkspaceState {


### PR DESCRIPTION
This PR builds upon the [recent titanium-editor-commons changes](https://github.com/tidev/titanium-editor-commons/releases/tag/v2.1.0) that added an `issues` array to the `validateEnvironment` function, which for now only checks that the selected SDK is installed.

On startup we now check if there are any issues with the environment and prompt the user to fix them before continuing on, given that these are intended to be problems with the environment that mean the extension cannot function til they are resolved we block loading until they are fixed.

Some potential future work here might be validating the `ti info` output and raising issues shown there.

The warning message looks like this
<img width="451" alt="image" src="https://user-images.githubusercontent.com/8705251/183216416-1b3c524d-0f20-4985-9871-ee434790e946.png">

And the sidebar view looks like this
<img width="317" alt="image" src="https://user-images.githubusercontent.com/8705251/183216470-c33c90a5-746e-40fb-8541-8d0dfc03ff9f.png">
