### PR TITLE
refactor: reduce number of activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "node": ">=14.16.0"
   },
   "activationEvents": [
-    "*"
+    "workspaceContains:**/tiapp.xml",
+    "onView:titanium"
   ],
   "capabilities": {
     "untrustedWorkspaces": {

--- a/src/test/unit/index.ts
+++ b/src/test/unit/index.ts
@@ -26,7 +26,7 @@ function setupCoverage () {
 
 export async function run (): Promise<void> {
 	const nyc = process.env.COVERAGE ? setupCoverage() : null;
-	const timeout = process.env.DEBUG ? 99999 : undefined;
+	const timeout = process.env.DEBUG ? 99999 : 5000;
 
 	const mocha = new Mocha({
 		ui: 'tdd',


### PR DESCRIPTION
This moves from the `*` activation event which means the extension is always activated to the following:

* `workspaceContains:**/tiapp.xml` - When the workspace has a tiapp.xml in a folder
* `onView:titanium` - When the `titanium` view is opened

We don't need to do any `onCommand` activation events as this is automatically done [as of VS Code 1.74](https://code.visualstudio.com/api/references/activation-events#onCommand) (which I think we should bump the minimum to on the next release)