### PR TITLE
fix(providers): always generate completion data after info load

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,6 +133,13 @@ export async function startup (): Promise<void> {
 			return;
 		}
 
+		// Generate completions for all SDK versions in app projects
+		for (const [ , project ] of ExtensionContainer.projects) {
+			if (project.type === 'app') {
+				await generateCompletions(false, project);
+			}
+		}
+
 		// Call refresh incase the Titanium Explorer activity pane became active before info
 		vscode.commands.executeCommand(Commands.RefreshExplorer);
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -144,20 +144,10 @@ export async function generateCompletions (force = false, project: Project): Pro
 		}
 		const sdkPath = sdkInfo.path;
 		// Generate the completions
-		const [ alloy, sdk ] = await Promise.all([
+		await Promise.all([
 			completion.generateAlloyCompletions(force, CompletionsFormat),
 			completion.generateSDKCompletions(force, sdkVersion, sdkPath, CompletionsFormat)
 		]);
-		if (sdk || alloy) {
-			let message = 'Autocomplete suggestions generated for';
-			if (sdk) {
-				message = `${message} Titanium ${sdk}`;
-			}
-			if (alloy) {
-				message = `${message} Alloy ${alloy}`;
-			}
-			vscode.window.showInformationMessage(message);
-		}
 	} catch (error) {
 		const actions: InteractionChoice[] = [];
 		if (error instanceof Errors.CustomError && error.code === 'ESDKNOTINSTALLED') {


### PR DESCRIPTION
In the initial load of projects we do not have environment information data and therefore no SDK data to generate completions from. So once we have loaded that environment data generate completions data for all of the app projects we have loaded.

Closes #1165