### PR TITLE
build: add helpers for managing l10n

### DIFF
--- a/scripts/diff-package-nls.js
+++ b/scripts/diff-package-nls.js
@@ -1,0 +1,22 @@
+const fs = require('fs-extra');
+const path = require('path');
+const primary = require('../package.nls.json');
+
+const regexp = /package.nls.(\w+).json/;
+const others = fs.readdirSync(path.join(__dirname, '..')).filter(item => regexp.test(item));
+const missing = {};
+const values = Object.entries(primary);
+
+for (const file of others) {
+	const [ , lang ] = regexp.exec(file);
+	missing[lang] = {};
+	const contents = fs.readJsonSync(path.join(__dirname, '..', file));
+
+	for (const [ key, value ] of values) {
+		if (!contents[key]) {
+			missing[lang][key] = value;
+		}
+	}
+}
+
+console.log(JSON.stringify(missing, null, 2));

--- a/scripts/write-package-nls.js
+++ b/scripts/write-package-nls.js
@@ -1,0 +1,67 @@
+const fs = require('fs-extra');
+const path = require('path');
+const packageJson = require('../package.json');
+const existing = require('../package.nls.json');
+
+function handleStringEdit (str, obj, key) {
+	if (!obj[key] || obj[key]?.startsWith('%')) {
+		return;
+	}
+	existing[str] = obj[key];
+	obj[key] = `%${str}%`;
+}
+
+const { contributes: { commands, configuration, debuggers, taskDefinitions, views, viewsWelcome } } = packageJson;
+
+for (let i = 0; i < commands.length; i++) {
+	const command = commands[i];
+	const leading = 'titanium.commands';
+	const suffix = command.command.replace('titanium.', '');
+	const cmdString = `${leading}.${suffix}`;
+
+	handleStringEdit(`${cmdString}.title`, command, 'title');
+	handleStringEdit(`${cmdString}.description`, command, 'description');
+}
+
+for (const [ key, value ] of Object.entries(configuration.properties)) {
+	const leading = 'titanium.config';
+	const suffix = key.replace('titanium.', '');
+	const configString = `${leading}.${suffix}`;
+
+	handleStringEdit(configString, value, 'description');
+}
+
+for (const [ key, value ] of Object.entries(debuggers[0].configurationAttributes.launch.properties)) {
+	handleStringEdit(`titanium.debug.${key}`, value, 'description');
+}
+
+for (let i = 0; i < taskDefinitions.length; i++) {
+	const { type, properties: { titaniumBuild } } = taskDefinitions[i];
+	const leading = `titanium.tasks.${type}`;
+
+	handleStringEdit(`${leading}.titaniumBuild`, titaniumBuild, 'description');
+
+	for (const [ key, value ] of Object.entries(titaniumBuild.properties)) {
+		let str = `${leading}.${key}`;
+		handleStringEdit(str, value, 'description');
+
+		if (value.type === 'object' || value.properties) {
+			for (const [ k, v ] of Object.entries(value.properties)) {
+				str = `${str}.${k}`;
+				handleStringEdit(str, v, 'description');
+			}
+		}
+	}
+}
+
+for (const value of views.titanium) {
+	handleStringEdit(value.id, value, 'name');
+}
+
+for (const value of viewsWelcome) {
+	const when = value.when.split(':')[1];
+	handleStringEdit(`${value.view}.${when}`, value, 'contents');
+}
+
+fs.writeJsonSync(path.join(__dirname, '..', 'package.json'), packageJson, { spaces: 2 });
+fs.writeJsonSync(path.join(__dirname, '..', '../package.nls.json'), existing, { spaces: 2 });


### PR DESCRIPTION
Just some scripts to help manage the l10n nls files moving forward as this doesn't seem to be part of vscode/l10n

* `write-package-nls` reads in the various places we can place strings and then writes the main file
* `diff-package-nls` then takes that file and compares each language file against it and prints any missing strings to the console