### PR TITLE
fix: building for MacAppStore

### DIFF
--- a/src/quickpicks/build/ios.ts
+++ b/src/quickpicks/build/ios.ts
@@ -27,7 +27,7 @@ export async function selectiOSProvisioningProfile (certificate: IosCert, target
 	let deployment: IosProvisioningType = 'development';
 	if (target === 'dist-adhoc') {
 		deployment = 'distribution';
-	} else if (target === 'dist-appstore') {
+	} else if (target === 'dist-appstore' || target === 'dist-macappstore') {
 		deployment = 'appstore';
 	}
 	const profiles = ExtensionContainer.environment.iOSProvisioningProfiles(deployment, certificate, appId);

--- a/src/tasks/helpers/base.ts
+++ b/src/tasks/helpers/base.ts
@@ -142,7 +142,7 @@ export abstract class TaskHelper {
 
 			const options = [ defaultLabel, 'Browse' ];
 
-			if ((definition as AppPackageTaskTitaniumBuildBase).target === 'dist-appstore') {
+			if ((definition as AppPackageTaskTitaniumBuildBase).target === 'dist-appstore' || (definition as AppPackageTaskTitaniumBuildBase).target === 'dist-macappstore') {
 				options.push('Output Into Xcode');
 			}
 

--- a/src/test/unit/suite/utils.test.ts
+++ b/src/test/unit/suite/utils.test.ts
@@ -90,23 +90,27 @@ describe('utils', () => {
 		expect(utils.nameForTarget('device')).to.equal('Device');
 		expect(utils.nameForTarget('emulator')).to.equal('Emulator');
 		expect(utils.nameForTarget('simulator')).to.equal('Simulator');
+		expect(utils.nameForTarget('macos')).to.equal('macOS');
 		expect(utils.nameForTarget('dist-adhoc')).to.equal('Ad-Hoc');
 		expect(utils.nameForTarget('dist-appstore')).to.equal('App Store');
 		expect(utils.nameForTarget('dist-playstore')).to.equal('Play Store');
+		expect(utils.nameForTarget('dist-macappstore')).to.equal('macOS App Store');
 	});
 
 	it('targetForName', () => {
 		expect(utils.targetForName('Device')).to.equal('device');
 		expect(utils.targetForName('Emulator')).to.equal('emulator');
 		expect(utils.targetForName('Simulator')).to.equal('simulator');
+		expect(utils.targetForName('macOS')).to.equal('macos');
 		expect(utils.targetForName('Ad-Hoc')).to.equal('dist-adhoc');
 		expect(utils.targetForName('App Store')).to.equal('dist-appstore');
 		expect(utils.targetForName('Play Store')).to.equal('dist-playstore');
+		expect(utils.targetForName('macOS App Store')).to.equal('dist-macappstore');
 	});
 
 	it('targetsForPlatform', () => {
 		expect(utils.targetsForPlatform('android')).to.deep.equal([ 'emulator', 'device', 'dist-playstore' ]);
-		expect(utils.targetsForPlatform('ios')).to.deep.equal([ 'simulator', 'device', 'dist-adhoc', 'dist-appstore' ]);
+		expect(utils.targetsForPlatform('ios')).to.deep.equal([ 'simulator', 'device', 'macos', 'dist-adhoc', 'dist-appstore', 'dist-macappstore' ]);
 	});
 
 	it('should be able to retrieve a device name', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,6 +81,8 @@ export function nameForTarget (target: Target): PrettyTarget {
 		case 'emulator':
 		case 'simulator':
 			return capitalizeFirstLetter(target) as PrettyDevelopmentTarget;
+		case 'macos':
+			return 'macOS';
 		case 'dist-adhoc':
 			return 'Ad-Hoc';
 		case 'dist-appstore':
@@ -109,6 +111,8 @@ export function targetForName (name: PrettyTarget): Target {
 			return 'dist-appstore';
 		case 'play store':
 			return 'dist-playstore';
+		case 'macos app store':
+			return 'dist-macappstore';
 		case 'device':
 		case 'emulator':
 		case 'simulator':
@@ -123,7 +127,7 @@ export function targetsForPlatform (platformName: Platform): Target[] {
 		case 'android':
 			return [ 'emulator', 'device', 'dist-playstore' ];
 		case 'ios':
-			return [ 'simulator', 'device', 'dist-adhoc', 'dist-appstore', 'dist-macappstore' ];
+			return [ 'simulator', 'device', 'macos', 'dist-adhoc', 'dist-appstore', 'dist-macappstore' ];
 		default:
 			return [];
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,7 +86,7 @@ export function nameForTarget (target: Target): PrettyTarget {
 		case 'dist-appstore':
 			return 'App Store';
 		case 'dist-macappstore':
-			return 'App Store';	
+			return 'macOS App Store';
 		case 'dist-playstore':
 			return 'Play Store';
 		default:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,6 +85,8 @@ export function nameForTarget (target: Target): PrettyTarget {
 			return 'Ad-Hoc';
 		case 'dist-appstore':
 			return 'App Store';
+		case 'dist-macappstore':
+			return 'App Store';	
 		case 'dist-playstore':
 			return 'Play Store';
 		default:
@@ -121,7 +123,7 @@ export function targetsForPlatform (platformName: Platform): Target[] {
 		case 'android':
 			return [ 'emulator', 'device', 'dist-playstore' ];
 		case 'ios':
-			return [ 'simulator', 'device', 'dist-adhoc', 'dist-appstore' ];
+			return [ 'simulator', 'device', 'dist-adhoc', 'dist-appstore', 'dist-macappstore' ];
 		default:
 			return [];
 	}


### PR DESCRIPTION
added: open in xcode, selecting provisioning profile for MacCatalyst (needs PR for titanium-sdk -> follows)