### PR TITLE
Include docs in version bump commit, lookup English l10n value when building docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This extension makes the following commands available in the Command Palette to 
 | `Titanium: Open related style` | Open related style |  Mac: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>s</kbd> <br> Windows/Linux: <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>s</kbd> |
 | `Titanium: Open related controller` | Open related controller |  Mac: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>x</kbd> <br> Windows/Linux: <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>x</kbd> |
 | `Titanium: Open related files` | Open related files |  Mac: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>a</kbd> <br> Windows/Linux: <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>a</kbd> |
+| `Titanium: Fix environment issues` | Fix environment issues | - |
 | `Titanium: Check For Updates` | Check For Updates | - |
 | `Titanium: Install All Updates` | Install All Updates | - |
 | `Titanium: Select Updates` | Select Updates | - |

--- a/package.json
+++ b/package.json
@@ -896,11 +896,11 @@
                     "description": "%titanium.tasks.titanium-package.android.keystore%",
                     "properties": {
                       "alias": {
-                        "description": "Alias for the keystore",
+                        "description": "titanium.tasks.titanium-package.android.keystore.alias",
                         "type": "string"
                       },
                       "location": {
-                        "description": "Path of the keystore to be used, must be a full path",
+                        "description": "titanium.tasks.titanium-package.android.keystore.location",
                         "type": "string"
                       }
                     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -72,6 +72,8 @@
   "titanium.tasks.titanium-package.titaniumBuild": "Properties used to configure the build",
   "titanium.tasks.titanium-package.android": "Properties used to configure Android builds",
   "titanium.tasks.titanium-package.android.keystore": "Keystore configuration",
+  "titanium.tasks.titanium-package.android.keystore.alias": "Alias for the keystore",
+  "titanium.tasks.titanium-package.android.keystore.location": "Path of the keystore to be used, must be a full path",
   "titanium.tasks.titanium-package.extraArguments": "Extra arguments to be used in the build",
   "titanium.tasks.titanium-package.ios": "Properties used to configure iOS builds",
   "titanium.tasks.titanium-package.ios.provisioningProfile": "Provisioning Profile UUID to be used",

--- a/release.config.js
+++ b/release.config.js
@@ -9,7 +9,12 @@ module.exports = {
 				packageVsix: true
 			}
 		],
-		'@semantic-release/git',
+		[
+			'@semantic-release/git',
+			{
+				assets: [ 'doc/', 'README.md', 'CHANGELOG.md', 'package.json', 'package-lock.json' ]
+			}
+		],
 		[
 			'@semantic-release/github',
 			{

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -2,6 +2,7 @@ const ejs = require('ejs');
 const fs = require('fs-extra');
 const packageJson = require('../package.json');
 const path = require('path');
+const strings = fs.readJSONSync(path.join(__dirname, '..', 'package.nls.json'));
 
 const renderObject = {
 	commands: generateCommands(),
@@ -40,8 +41,8 @@ function generateCommands() {
 			continue;
 		}
 		commandInformation.push({
-			name: `\`${category}: ${title}\``,
-			description: description || title,
+			name: `\`${category}: ${getEnglishl10nValue(title)}\``,
+			description: getEnglishl10nValue(description || title),
 			keybinding
 		});
 
@@ -56,7 +57,7 @@ function generateSettings() {
 		const defaultValue = settingInfo.default === null || settingInfo.default.length === 0 ? 'No Default' : settingInfo.default;
 		settingsInformation.push({
 			name: `\`${name}\``,
-			description: settingInfo.description,
+			description: getEnglishl10nValue(settingInfo.description),
 			defaultValue: `\`${defaultValue}\``
 		});
 	}
@@ -104,7 +105,7 @@ function generateSnippets() {
 		for (const { description, prefix } of Object.values(snippetDefinitions)) {
 			snippetInfo.push({
 				prefix: `\`${prefix}\``,
-				description
+				description: description
 			});
 		}
 		if (description.includes('Titanium')) {
@@ -127,7 +128,7 @@ function generateDebugProperties () {
 	for (const [ name, information ] of Object.entries(properties)) {
 		debuggingInformation.launch.push({
 			name,
-			description: information.description,
+			description: getEnglishl10nValue(information.description),
 			defaultValue: information.defaultValue,
 			required: required.includes(name)
 		});
@@ -186,7 +187,7 @@ function recurseProperties(properties, platform, taskType, propertyPrefix = 'tit
 		}
 		propertyData.push({
 			name: `\`${propertyPrefix}.${name}\``,
-			description: information.description,
+			description: getEnglishl10nValue(information.description),
 			defaultValue: information.defaultValue,
 			validValues: information.enum ? information.enum.map(value => `\`${value}\``).join(', ') : 'N/A'
 		});
@@ -195,4 +196,13 @@ function recurseProperties(properties, platform, taskType, propertyPrefix = 'tit
 		return `There are no ${platform} specific configuration properties for the ${taskType} task.`;
 	}
 	return propertyData;
+}
+
+function getEnglishl10nValue(name) {
+	const val = strings[name.replaceAll('%', '')];
+	if (!val) {
+		console.warn(`Failed to lookup ${name} in package.nls.json`);
+		return '';
+	}
+	return val;
 }


### PR DESCRIPTION
Updates the semantic-release config to add the built docs to the version bump commit.

Also updates the docs build script to grab the value from the package.nls.json file