### PR TITLE
feat: update editor commons to use newer node version range in empty state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "ms": "^2.1.3",
         "semver": "^7.3.5",
         "source-map": "^0.7.4",
-        "titanium-editor-commons": "^2.1.0",
+        "titanium-editor-commons": "^2.2.0",
         "uuid": "^9.0.0",
         "vscode-chrome-debug-core": "^6.8.11",
         "vscode-debugadapter": "^1.51.0",
@@ -17577,9 +17577,10 @@
       }
     },
     "node_modules/titanium-editor-commons": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-2.1.0.tgz",
-      "integrity": "sha512-JfpZ/2VrsLErq88tdZF/k7c04HLkoyv/ftum4ZYiowfZrYw8TEKE7/Eyw27PTrqS/pYd7UQequKvwPc2dpaXTg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-2.2.0.tgz",
+      "integrity": "sha512-lHr3mA6xx7AlY0kTm0YOouq1ErRB1JObkvTDtOE+FBoPOoYn9T+VhXlv9z8iNvzHlvk5Ij4i74iiEkt3aU7C+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "execa": "^5.0.0",
         "fs-extra": "^10.0.0",
@@ -17587,7 +17588,7 @@
         "semver": "^7.1.3"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/titanium-editor-commons/node_modules/cross-spawn": {
@@ -31732,9 +31733,9 @@
       }
     },
     "titanium-editor-commons": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-2.1.0.tgz",
-      "integrity": "sha512-JfpZ/2VrsLErq88tdZF/k7c04HLkoyv/ftum4ZYiowfZrYw8TEKE7/Eyw27PTrqS/pYd7UQequKvwPc2dpaXTg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-2.2.0.tgz",
+      "integrity": "sha512-lHr3mA6xx7AlY0kTm0YOouq1ErRB1JObkvTDtOE+FBoPOoYn9T+VhXlv9z8iNvzHlvk5Ij4i74iiEkt3aU7C+Q==",
       "requires": {
         "execa": "^5.0.0",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1067,7 +1067,7 @@
     "ms": "^2.1.3",
     "semver": "^7.3.5",
     "source-map": "^0.7.4",
-    "titanium-editor-commons": "^2.1.0",
+    "titanium-editor-commons": "^2.2.0",
     "uuid": "^9.0.0",
     "vscode-chrome-debug-core": "^6.8.11",
     "vscode-debugadapter": "^1.51.0",


### PR DESCRIPTION
Including https://github.com/tidev/titanium-editor-commons/pull/816 